### PR TITLE
Rational lens

### DIFF
--- a/ArithmeticTools/Rational.swift
+++ b/ArithmeticTools/Rational.swift
@@ -37,17 +37,19 @@ public protocol Rational:
     /// Create a `Rational` value with a given `numerator` and `denominator`.
     init(_ numerator: Int, _ denominator: Int)
     
-    /// Representation `Rational` value with a given `numerator`, if possible. Otherwise,
-    /// `nil`.
+    /// - returns: Representation of a `Rational` value with a given `numerator`, if possible.
+    /// Otherwise, `nil`.
     func with(numerator: Int) -> Self?
     
-    /// Representation `Rational` value with a given `denominator`, if possible. Otherwise,
-    /// `nil`.
+    /// - returns: Representation of a `Rational` value with a given `denominator`, if
+    /// possible. Otherwise, `nil`.
     func with(denominator: Int) -> Self?
 }
 
 extension Rational {
     
+    /// - returns: Representation of a `Rational` value with a given `numerator`, if possible.
+    /// Otherwise, `nil`.
     public func with(numerator newNumerator: Int) -> Self? {
         
         guard newNumerator != numerator else {
@@ -64,6 +66,8 @@ extension Rational {
         return Self(newNumerator, Int(newDenominator))
     }
     
+    /// - returns: Representation of a `Rational` value with a given `denominator`, if
+    /// possible. Otherwise, `nil`.
     public func with(denominator newDenominator: Int) -> Self? {
         
         guard newDenominator != denominator else {

--- a/ArithmeticTools/Rational.swift
+++ b/ArithmeticTools/Rational.swift
@@ -48,12 +48,36 @@ public protocol Rational:
 
 extension Rational {
     
-    public func with(numerator: Int) -> Self? {
-        return nil
+    public func with(numerator newNumerator: Int) -> Self? {
+        
+        guard newNumerator != numerator else {
+            return self
+        }
+        
+        let quotient = Float(newNumerator) / Float(numerator)
+        let newDenominator = Float(denominator) * quotient
+        
+        guard newDenominator.truncatingRemainder(dividingBy: 1) == 0 else {
+            return nil
+        }
+        
+        return Self(newNumerator, Int(newDenominator))
     }
     
-    public func with(denominator: Int) -> Self? {
-        return nil
+    public func with(denominator newDenominator: Int) -> Self? {
+        
+        guard newDenominator != denominator else {
+            return self
+        }
+        
+        let quotient = Float(newDenominator) / Float(denominator)
+        let newNumerator = Float(numerator) * quotient
+        
+        guard newNumerator.truncatingRemainder(dividingBy: 1) == 0 else {
+            return nil
+        }
+
+        return Self(Int(newNumerator), newDenominator)
     }
 }
 

--- a/ArithmeticTools/Rational.swift
+++ b/ArithmeticTools/Rational.swift
@@ -36,13 +36,32 @@ public protocol Rational:
     
     /// Create a `Rational` value with a given `numerator` and `denominator`.
     init(_ numerator: Int, _ denominator: Int)
+    
+    /// Representation `Rational` value with a given `numerator`, if possible. Otherwise,
+    /// `nil`.
+    func with(numerator: Int) -> Self?
+    
+    /// Representation `Rational` value with a given `denominator`, if possible. Otherwise,
+    /// `nil`.
+    func with(denominator: Int) -> Self?
+}
+
+extension Rational {
+    
+    public func with(numerator: Int) -> Self? {
+        return nil
+    }
+    
+    public func with(denominator: Int) -> Self? {
+        return nil
+    }
 }
 
 extension Rational {
     
     /// - returns: `true` if `self` is equivalent to its most-reduced form.
     public var isReduced: Bool {
-        return self == self.reduced
+        return self == reduced
     }
 }
 

--- a/ArithmeticToolsTests/RationalTests.swift
+++ b/ArithmeticToolsTests/RationalTests.swift
@@ -79,4 +79,56 @@ class RationalTests: XCTestCase {
         let b = R(11,10948)
         XCTAssertNotEqual(a.hashValue, b.hashValue)
     }
+    
+    func testRespellWithNumeratorEqualToSelfValid() {
+        let original = R(1,13)
+        let new = original.with(numerator: 1)!
+        XCTAssertEqual(new.numerator, 1)
+        XCTAssertEqual(new.denominator, 13)
+    }
+    
+    func testRespellWithNumeratorGreaterThanValid() {
+        let original = R(1,13)
+        let new = original.with(numerator: 3)!
+        XCTAssertEqual(new.numerator, 3)
+        XCTAssertEqual(new.denominator, 39)
+    }
+    
+    func testRespellWithNumeratorLessThanValid() {
+        let original = R(5,15)
+        let new = original.with(numerator: 1)!
+        XCTAssertEqual(new.numerator, 1)
+        XCTAssertEqual(new.denominator, 3)
+    }
+    
+    func testRespellWithDenominatorEqualToSelfValid() {
+        let original = R(1,13)
+        let new = original.with(denominator: 13)!
+        XCTAssertEqual(new.numerator, 1)
+        XCTAssertEqual(new.denominator, 13)
+    }
+    
+    func testRespellWithDenominatorLessThanValid() {
+        let original = R(5,10)
+        let new = original.with(denominator: 6)!
+        XCTAssertEqual(new.numerator, 3)
+        XCTAssertEqual(new.denominator, 6)
+    }
+    
+    func testRespellWithDenominatorGreaterThanValid() {
+        let original = R(3,12)
+        let new = original.with(denominator: 48)!
+        XCTAssertEqual(new.numerator, 12)
+        XCTAssertEqual(new.denominator, 48)
+    }
+    
+    func testRespellWithDenominatorLessThanNil() {
+        let original = R(3,7)
+        XCTAssertNil(original.with(denominator: 6))
+    }
+    
+    func testRespellWithDenominatorGreaterThanNil() {
+        let original = R(3,7)
+        XCTAssertNil(original.with(denominator: 8))
+    }
 }

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "dn-m/Collections" "1.2"
+github "dn-m/Collections" "1.6.2"


### PR DESCRIPTION
Add lens-like operation to create a new `Rational` type with updated `numerator` or `denominator` properties.

Called as:

```Swift
let original = R(1,3)
let new = original.with(numerator: 3) // (3,15)
```

and

```Swift
let original = R(5,12)
let new = original.with(denominator: 24) // (10,24)
```