### PR TITLE
Remove old terrible invert(powerOfTwo:within)

### DIFF
--- a/ArithmeticTools.xcodeproj/project.pbxproj
+++ b/ArithmeticTools.xcodeproj/project.pbxproj
@@ -310,8 +310,8 @@
 				077554671E1B013400CF4A8A /* RationalTests.swift */,
 				0799D96E1E21777A00516ADF /* QuadraticTests.swift */,
 				07C563B11E22B88700E73FB2 /* BitwiseOperationsTests.swift */,
-				074276C51C8767FD00D50A30 /* Supporting Files */,
 				07D91CDF1E4CE7B8006DBA11 /* InvertibleOptionSetTests.swift */,
+				074276C51C8767FD00D50A30 /* Supporting Files */,
 			);
 			path = ArithmeticToolsTests;
 			sourceTree = "<group>";

--- a/ArithmeticTools/BitwiseOperations.swift
+++ b/ArithmeticTools/BitwiseOperations.swift
@@ -8,24 +8,6 @@
 
 import Foundation
 
-/// Log base 2 of an Integer.
-///
-/// - warning: This is only accurate if you know this a power-of-two!
-public func log2(powerOfTwo x: Int) -> Int {
-    return Int(log2(Float(x)))
-}
-
-/// Takes an integer that is a power-of-two (e.g., `1 << 3`).
-/// This retrieves the right-hand-side value, then inverts this value in relation to the given
-/// `max` value. The returned value can then be re-shifted as necessary.
-///
-///     invert(powerOfTwo: 1 << 3, within: 4) // 1
-///
-public func invert(powerOfTwo: Int, within max: Int) -> Int {
-    let unrolled = log2(powerOfTwo: powerOfTwo)
-    return max - unrolled
-}
-
 private let intBitCount = MemoryLayout<Int>.size * 8
 
 /// Count Trailing Zeros (ctz) counts the number of zero bits succeeding the least

--- a/ArithmeticTools/InvertibleOptionSet.swift
+++ b/ArithmeticTools/InvertibleOptionSet.swift
@@ -6,16 +6,20 @@
 //  Copyright © 2017 James Bean. All rights reserved.
 //
 
+/// Interface for types which have an inverse.
+public protocol Invertible {
+    
+    /// Inverse of `self`.
+    var inverse: Self { get }
+}
+
 /// Interface for `OptionSet` types which are symmetrically defined.
 ///
 /// - invariant: The options are defined with `rawValue` values of 
 /// `(1 << 0) ... (1 << optionsCount - 1)`.
-public protocol InvertibleOptionSet: OptionSet {
+public protocol InvertibleOptionSet: OptionSet, Invertible {
     
-    /// Inverse of the current option.
-    var inverse: Self { get }
-    
-    /// Amount of options in `self`.
+        /// Amount of options in `self`.
     var optionsCount: Int { get }
 }
 

--- a/ArithmeticToolsTests/BitwiseOperationsTests.swift
+++ b/ArithmeticToolsTests/BitwiseOperationsTests.swift
@@ -12,32 +12,7 @@ import ArithmeticTools
 class BitwiseOperationsTests: XCTestCase {
     
     let intBitCount = MemoryLayout<Int>.size * 8
-    
-    func testLog2IntPowerOfTwo() {
-        let x = 1 << 4
-        XCTAssertEqual(log2(powerOfTwo: x), 4)
-    }
-    
-    func testInvertSameZero() {
         
-        let powerOfTwo = 1 << 0
-        let max = 0
-        let result = invert(powerOfTwo: powerOfTwo, within: max)
-        let expected = 0
-        
-        XCTAssertEqual(result, expected)
-    }
-    
-    func testInvert() {
-
-        let powerOfTwo = 1 << 6
-        let max = 7
-        let result = 1 << invert(powerOfTwo: powerOfTwo, within: max)
-        let expected = 1 << 1
-        
-        XCTAssertEqual(result, expected)
-    }
-    
     func testCountLeadingZeros() {
         XCTAssertEqual(countLeadingZeros(-1), 0)
         XCTAssertEqual(countLeadingZeros(-112348123), 0)


### PR DESCRIPTION
- Removes `invert(powerOfTwo:within:)`
- Adds `Invertible` protocol
- Removes `inverse` declaration from `InvertibleOptionSet`