### PR TITLE
Fix accumulatingLeft, add tests

### DIFF
--- a/ArithmeticTools/BidirectionalCollectionExtensions.swift
+++ b/ArithmeticTools/BidirectionalCollectionExtensions.swift
@@ -37,8 +37,10 @@ extension Collection where Iterator.Element: Monoid {
         return accumulate(Array(self), result: [], sum: .unit)
     }
     
+    /// - returns: An array of the values contained herein accumulating the running sum to the
+    /// left, start with `.unit`.
     public var accumulatingLeft: [Iterator.Element] {
-        return reversed().accumulatingRight.reversed()
+        return reversed().accumulatingRight
     }
 }
 

--- a/ArithmeticToolsTests/CumulativeTests.swift
+++ b/ArithmeticToolsTests/CumulativeTests.swift
@@ -11,18 +11,33 @@ import Collections
 import ArithmeticTools
 
 class CumulativeTests: XCTestCase {
-    
-    func testIntArrayCumulative() {
+
+    func testIntArrayCumulativeRight() {
         let array = [1,2,3]
         XCTAssertEqual(array.accumulatingRight, [0,1,3])
     }
-    
-    func testFloatArrayCumulative() {
+
+    func testFloatArrayCumulativeRight() {
 
         let array = [1.1, 2.2, 3.3]
         let expected = [0, 1.1, 3.3]
-        
+
         zip(array.accumulatingRight, expected).forEach { actual, expected in
+            XCTAssertEqualWithAccuracy(actual, expected, accuracy: 0.000001)
+        }
+    }
+
+    func testIntArrayCumulativeLeft() {
+        let array = [1,2,3]
+        XCTAssertEqual(array.accumulatingLeft, [0,3,5])
+    }
+
+    func testFloatArrayCumulativeLeft() {
+
+        let array = [1.1, 2.2, 3.3]
+        let expected = [0, 3.3, 5.5]
+
+        zip(array.accumulatingLeft, expected).forEach { actual, expected in
             XCTAssertEqualWithAccuracy(actual, expected, accuracy: 0.000001)
         }
     }


### PR DESCRIPTION
- Add documentation
- Don't do a second reverse, so that the output behaves as expected
- Add tests to confirm new behavior

@jsbean, is this output really what's expected? I would have expected `[1,2,3].accumulatingRight` to be `[1,3,6]`, and leftwise `[3,5,6]`.