### PR TITLE
Rename closestPowerOfTwo(withCoefficient:to:)

### DIFF
--- a/ArithmeticTools/Power.swift
+++ b/ArithmeticTools/Power.swift
@@ -18,35 +18,35 @@ import Foundation
  - returns: Power-of-two value closest to target value
  */
 public func closestPowerOfTwo(to target: Int) -> Int? {
-    return closestPowerOfTwo(withCoefficient: 2, to: target)
+    return closestPowerOfTwo(coefficient: 2, to: target)
 }
 
 /**
  - returns: Power-of-two value closest to and less than target value
  */
 public func closestPowerOfTwo(under target: Int) -> Int? {
-    return closestPowerOfTwo(withCoefficient: 2, under: target)
+    return closestPowerOfTwo(coefficient: 2, under: target)
 }
 
 /**
- >`closestPowerOfTwo(withCoefficient: 3, to: 22) -> 24`
+ >`closestPowerOfTwo(coefficient: 3, to: 22) -> 24`
 
  - note: If two values are equidistant from the target value, the lesser value is returned.
  
- >`closestPowerOfTwo(withCoefficient: 3, to: 18) -> 12 (not 24)`
+ >`closestPowerOfTwo(coefficient: 3, to: 18) -> 12 (not 24)`
  
  - parameter coefficient: Coefficient of exponential expression
  - parameter target:      Value to check for closest power-of-two
  
  - returns: Power-of-two value (with coefficient) closest to target value
  */
-public func closestPowerOfTwo(withCoefficient coefficient: Int, to target: Int) -> Int? {
+public func closestPowerOfTwo(coefficient: Int, to target: Int) -> Int? {
     let sequence = PowerSequence(coefficient: coefficient, max: target, doOvershoot: true)
     return closer(to: sequence, target: target)
 }
 
 /// - returns: Power-of-two (with coefficient) closest to and less than target value
-public func closestPowerOfTwo(withCoefficient coefficient: Int, under target: Int) -> Int? {
+public func closestPowerOfTwo(coefficient: Int, under target: Int) -> Int? {
     let sequence = PowerSequence(coefficient: coefficient, max: target, doOvershoot: false)
     return closer(to: sequence, target: target)
 }

--- a/ArithmeticToolsTests/PowerTests.swift
+++ b/ArithmeticToolsTests/PowerTests.swift
@@ -22,17 +22,17 @@ class PowerTests: XCTestCase {
     }
     
     func testClosestPowerOf2_coeff2() {
-        let closest = closestPowerOfTwo(withCoefficient: 2, to: 13)!
+        let closest = closestPowerOfTwo(coefficient: 2, to: 13)!
         XCTAssertEqual(closest, 16)
     }
     
     func testClosestPowerOf2_coeff3() {
-        let closest = closestPowerOfTwo(withCoefficient: 3, to: 11)!
+        let closest = closestPowerOfTwo(coefficient: 3, to: 11)!
         XCTAssertEqual(closest, 12)
     }
     
     func testClosestPowerOf2_coeff11() {
-        let closest = closestPowerOfTwo(withCoefficient: 11, to: 13)!
+        let closest = closestPowerOfTwo(coefficient: 11, to: 13)!
         XCTAssertEqual(closest, 11)
     }
     


### PR DESCRIPTION
Rename closestPowerOfTwo(withCoefficient:to:) ->
closestPowerOfTwo(coefficient:to:)

Fixes #69 