### PR TITLE
De-optionalize Rational and Fraction respelling(numerator:/denominator:)

### DIFF
--- a/ArithmeticTools/Rational.swift
+++ b/ArithmeticTools/Rational.swift
@@ -183,6 +183,10 @@ extension Rational {
             return self
         }
 
+        guard numerator == 0 else {
+            return Self(0, newDenominator)
+        }
+
         let quotient = Float(newDenominator) / Float(denominator)
         let newNumerator = Float(numerator) * quotient
 

--- a/ArithmeticTools/Rational.swift
+++ b/ArithmeticTools/Rational.swift
@@ -183,7 +183,7 @@ extension Rational {
             return self
         }
 
-        guard numerator == 0 else {
+        guard numerator != 0 else {
             return Self(0, newDenominator)
         }
 

--- a/ArithmeticTools/Rational.swift
+++ b/ArithmeticTools/Rational.swift
@@ -103,13 +103,13 @@ public protocol Rational:
     /// Otherwise, `nil`.
     ///
     /// > Preserves the arithmetic value of the original `Rational` value.
-    func respelling(numerator: Int) -> Self?
+    func respelling(numerator: Int) -> Self
 
     /// - returns: Representation of a `Rational` value with a given `denominator`, if
     /// possible. Otherwise, `nil`.
     ///
     /// > Preserves the arithmetic value of the original `Rational` value.
-    func respelling(denominator: Int) -> Self?
+    func respelling(denominator: Int) -> Self
 
     /// - returns: A new `Rational` value with the given `numerator`, which is no longer
     /// guaranteed to provide the same arithmetic value as before.
@@ -159,7 +159,7 @@ extension Rational {
 
     /// - returns: Representation of a `Rational` value with a given `numerator`, if possible.
     /// Otherwise, `nil`.
-    public func respelling(numerator newNumerator: Int) -> Self? {
+    public func respelling(numerator newNumerator: Int) -> Self {
 
         guard newNumerator != numerator else {
             return self
@@ -175,7 +175,7 @@ extension Rational {
 
     /// - returns: Representation of a `Rational` value with a given `denominator`, if
     /// possible. Otherwise, `nil`.
-    public func respelling(denominator newDenominator: Int) -> Self? {
+    public func respelling(denominator newDenominator: Int) -> Self {
 
         guard newDenominator != denominator else {
             return self
@@ -333,7 +333,7 @@ extension Rational {
     /// - returns: Pair of `Rational` values, with common denominators.
     public static func normalized <R: Rational> (_ a: R, _ b: R) -> (R, R) {
         let commonDenominator = lcm(a.denominator, b.denominator)
-        return map(a,b) { $0.respelling(denominator: commonDenominator)! }
+        return map(a,b) { $0.respelling(denominator: commonDenominator) }
     }
 
     /// - returns: `true` if both values are equivalent in their most-reduced form.

--- a/ArithmeticTools/Rational.swift
+++ b/ArithmeticTools/Rational.swift
@@ -165,8 +165,8 @@ extension Rational {
             return self
         }
 
-        let quotient = Float(newNumerator) / Float(numerator)
-        let newDenominator = Float(denominator) * quotient
+        let quotient = Double(newNumerator) / Double(numerator)
+        let newDenominator = Double(denominator) * quotient
 
         guard newDenominator.truncatingRemainder(dividingBy: 1) == 0 else {
             return nil
@@ -187,8 +187,8 @@ extension Rational {
             return Self(0, newDenominator)
         }
 
-        let quotient = Float(newDenominator) / Float(denominator)
-        let newNumerator = Float(numerator) * quotient
+        let quotient = Double(newDenominator) / Double(denominator)
+        let newNumerator = Double(numerator) * quotient
 
         guard newNumerator.truncatingRemainder(dividingBy: 1) == 0 else {
             return nil

--- a/ArithmeticTools/Rational.swift
+++ b/ArithmeticTools/Rational.swift
@@ -100,13 +100,12 @@ public protocol Rational:
     init(_ numerator: Int, _ denominator: Int)
 
     /// - returns: Representation of a `Rational` value with a given `numerator`, if possible.
-    /// Otherwise, `nil`.
     ///
     /// > Preserves the arithmetic value of the original `Rational` value.
     func respelling(numerator: Int) -> Self
 
     /// - returns: Representation of a `Rational` value with a given `denominator`, if
-    /// possible. Otherwise, `nil`.
+    /// possible. Assumes the denominator is not 0.
     ///
     /// > Preserves the arithmetic value of the original `Rational` value.
     func respelling(denominator: Int) -> Self
@@ -157,8 +156,7 @@ extension Rational {
 
 extension Rational {
 
-    /// - returns: Representation of a `Rational` value with a given `numerator`, if possible.
-    /// Otherwise, `nil`.
+    /// - returns: Representation of a `Rational` value with a given `numerator`.
     public func respelling(numerator newNumerator: Int) -> Self {
 
         guard newNumerator != numerator else {
@@ -173,8 +171,7 @@ extension Rational {
         return Self(newNumerator, Int(newDenominator))
     }
 
-    /// - returns: Representation of a `Rational` value with a given `denominator`, if
-    /// possible. Otherwise, `nil`.
+    /// - returns: Representation of a `Rational` value with a given `denominator`.
     public func respelling(denominator newDenominator: Int) -> Self {
 
         guard newDenominator != denominator else {

--- a/ArithmeticTools/Rational.swift
+++ b/ArithmeticTools/Rational.swift
@@ -168,9 +168,7 @@ extension Rational {
         let quotient = Double(newNumerator) / Double(numerator)
         let newDenominator = Double(denominator) * quotient
 
-        guard newDenominator.truncatingRemainder(dividingBy: 1) == 0 else {
-            return nil
-        }
+        assert(newDenominator.truncatingRemainder(dividingBy: 1) == 0)
 
         return Self(newNumerator, Int(newDenominator))
     }
@@ -190,9 +188,7 @@ extension Rational {
         let quotient = Double(newDenominator) / Double(denominator)
         let newNumerator = Double(numerator) * quotient
 
-        guard newNumerator.truncatingRemainder(dividingBy: 1) == 0 else {
-            return nil
-        }
+        assert(newNumerator.truncatingRemainder(dividingBy: 1) == 0)
 
         return Self(Int(newNumerator), newDenominator)
     }

--- a/ArithmeticToolsTests/RationalTests.swift
+++ b/ArithmeticToolsTests/RationalTests.swift
@@ -98,54 +98,44 @@ class RationalTests: XCTestCase {
 
     func testRespellWithNumeratorEqualToSelfValid() {
         let original = Fraction(1,13)
-        let new = original.respelling(numerator: 1)!
+        let new = original.respelling(numerator: 1)
         XCTAssertEqual(new.numerator, 1)
         XCTAssertEqual(new.denominator, 13)
     }
 
     func testRespellWithNumeratorGreaterThanValid() {
         let original = Fraction(1,13)
-        let new = original.respelling(numerator: 3)!
+        let new = original.respelling(numerator: 3)
         XCTAssertEqual(new.numerator, 3)
         XCTAssertEqual(new.denominator, 39)
     }
 
     func testRespellWithNumeratorLessThanValid() {
         let original = Fraction(5,15)
-        let new = original.respelling(numerator: 1)!
+        let new = original.respelling(numerator: 1)
         XCTAssertEqual(new.numerator, 1)
         XCTAssertEqual(new.denominator, 3)
     }
 
     func testRespellWithDenominatorEqualToSelfValid() {
         let original = Fraction(1,13)
-        let new = original.respelling(denominator: 13)!
+        let new = original.respelling(denominator: 13)
         XCTAssertEqual(new.numerator, 1)
         XCTAssertEqual(new.denominator, 13)
     }
 
     func testRespellWithDenominatorLessThanValid() {
         let original = Fraction(5,10)
-        let new = original.respelling(denominator: 6)!
+        let new = original.respelling(denominator: 6)
         XCTAssertEqual(new.numerator, 3)
         XCTAssertEqual(new.denominator, 6)
     }
 
     func testRespellWithDenominatorGreaterThanValid() {
         let original = Fraction(3,12)
-        let new = original.respelling(denominator: 48)!
+        let new = original.respelling(denominator: 48)
         XCTAssertEqual(new.numerator, 12)
         XCTAssertEqual(new.denominator, 48)
-    }
-
-    func testRespellWithDenominatorLessThanNil() {
-        let original = Fraction(3,7)
-        XCTAssertNil(original.respelling(denominator: 6))
-    }
-
-    func testRespellWithDenominatorGreaterThanNil() {
-        let original = Fraction(3,7)
-        XCTAssertNil(original.respelling(denominator: 8))
     }
 
     // MARK: - Arithmetic


### PR DESCRIPTION
Fixes #110. Also does math using doubles rather than floats.

Also, respelling(denominator:) now guards against the case where numerator==0.